### PR TITLE
extend the documentation

### DIFF
--- a/docs/building_pydrofoil.md
+++ b/docs/building_pydrofoil.md
@@ -1,22 +1,53 @@
-# Building pydrofoil from source
+# Building Pydrofoil from source
 
-TL;DR: run `make pydrofoil-riscv`.
+On this page we'll describe how to build or download a Pydrofoil binary.
 
-And for the rest of the story:
+## Requirements
 
-Pydrofoil uses three inputs: 
-- A SAIL IR file that describes the RISCV archtecture, in the JIB format
-- A checkout of the pydrosail repo, which contains source code in RPython to
-  build an emulator around the IR file.
-- A RPython tool chain that will compile the emulator code and produce an
-  executable.
+So far, Pydrofoil is only properly supported on Linux and WSL, on x86-64 host
+CPUs. macOS and ARM host support is planned, but not yet ready.
 
-If you modify the RISCV description file, you must rebuild the emulator
-executable.
+To build Pydrofoil, you need a working C-compiler (gcc or clang) installed, as
+well as GNU Make. You also need Sail installed to be able to work on the
+Sail model itself. [At the
+moment](https://github.com/pydrofoil/pydrofoil/issues/31) Pydrofoil only works
+with Sail 0.14, but we are working on 0.15 support. All the other Pydrofoil
+requirements are downloaded automatically by the build scripts/Makefile.
 
-There is a Makefile in the root of the repo that will rebuild the emulator:
-- Get a pypy2.7 in order to run the RPython code
-- Get a rpython toolchain from https://github.com/mozillazg/pypy, which is a git mirror of the upstream mercurial PyPy repo.
-- Build the emulator `
+## Starting from a Sail-riscv checkout
 
-This is done via `make pydrofoil-riscv`. This should run on any platform [supported by PyPy](https://www.pypy.org/features.html), we test x86_64 linux in CI.
+If you already have a checkout of the [Sail-RISC-V
+model](https://github.com/riscv/sail-riscv) there is a script that you can use
+to download all the requirements for building Pydrofoil and then start the build
+process. It works like this:
+
+```
+git clone https://github.com/riscv/sail-riscv.git # or use your existing checkout
+cd sail-riscv
+wget https://raw.githubusercontent.com/pydrofoil/pydrofoil/one-stop-build-script/build-pydrofoil-from-sail.sh
+bash build-pydrofoil-from-sail.sh
+building pydrofoil binary, takes about 20 min
+... lots of output
+```
+
+After about 20 minutes, the binary `pydrofoil-riscv` is generated, you can test
+that it worked like this:
+
+```
+./pydrofoil-riscv test/riscv-tests/rv64ui-p-beq.elf
+tohost located at 0x80001000
+entrypoint 0x80000000
+CSR mstatus <- 0x0000000A00000000 (input: 0x0000000000000000)
+SUCCESS
+Instructions: 305
+Total time (s): 0.000361
+Perf: 844.397835 Kips
+```
+
+[See here](using_pydrofoil.md) for more instructions on how to use Pydrofoil.
+
+
+## If you are working on Pydrofoil itself
+
+If you are interested in working on Pydrofoil itself, please read the
+instructions on the page [Developing Pydrofoil](developing_pydrofoil.md).

--- a/docs/developing_pydrofoil.md
+++ b/docs/developing_pydrofoil.md
@@ -1,0 +1,52 @@
+# Developing Pydrofoil
+
+This page collects instructions on how various things work when you want to work
+on Pydrofoil itself.
+
+To get started, you should clone the Pydrofoil repository:
+
+```
+git clone https://github.com/pydrofoil/pydrofoil.git
+```
+
+## Building Pydrofoil emulator binary
+
+To build the Pydrofoil emulator binary you can run:
+
+```
+make pydrofoil-riscv
+```
+
+And for the rest of the story:
+
+Pydrofoil uses three inputs:
+- A SAIL IR file that describes the RISC-V architecture, automatically generated
+  from the Sail model of RISC-V.
+- A checkout of the Pydrofoil repo, which contains source code in RPython to
+  build an emulator around the IR file.
+- A RPython tool chain that will compile the emulator code and produce an
+  executable.
+
+If you modify the RISC-V description file, you must rebuild the emulator
+executable.
+
+There is a Makefile in the root of the repo that will rebuild the emulator:
+- Get a PyPy2.7 binary in order to run the RPython code
+- Get the RPython toolchain from https://github.com/mozillazg/pypy, which is a git mirror of the [upstream mercurial PyPy repo](https://foss.heptapod.net/pypy/pypy).
+- Build the emulator
+
+This is done via `make pydrofoil-riscv`. At the moment the Makefile and the
+build scripts only supports x86-64 Linux and WSL, but it should be possible to
+get this to work on any platform [supported by
+PyPy](https://www.pypy.org/features.html).
+
+
+## Running unit tests
+
+Pydrofoil has a number of unit tests to check the correct behaviour of its
+bitvector implementation and the rest of its support code. Those can be run
+with:
+
+```
+make pydrofoil-test
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,9 @@ all its optimizations, backends, etc.
    :maxdepth: 1
    :hidden:
 
-    Building pydrofoil <building_pydrofoil>
-    Using pydrofoil <using_pydrofoil>
+    Building Pydrofoil <building_pydrofoil>
+    Using Pydrofoil <using_pydrofoil>
+    Developing Pydrofoil <developing_pydrofoil>
     Useful links <useful_links>
 
 .. __: https://github.com/riscv/sail-riscv

--- a/docs/using_pydrofoil.md
+++ b/docs/using_pydrofoil.md
@@ -1,13 +1,15 @@
-# Using pydrofoil
+# Using Pydrofoil
 
-## Testing compiled RISCV executables
+## Testing compiled RISC-V executables
 
-Pydrofoil accepts a compiled RISCV exectuable and will run it. Typically, the
-source code of the executable will test some RISCV feature and report
-success/failure.
+Pydrofoil accepts a compiled RISC-V executable and will run it. Typically, the
+source code of the executable will test some RISC-V feature and report
+success/failure. It should work on the same ELF files that the standard
+Sail-based emulator also accepts. The following example commands should be
+executed from a sail-riscv checkout.
 
 ```
-$ ./pydrofoil-riscv riscv/input/rv64ui-p-addi.elf 
+$ ./pydrofoil-riscv test/riscv-tests/rv64ui-p-addi.elf
 tohost located at 0x80001000
 entrypoint 0x80000000
 CSR mstatus <- 0x0000000A00000000 (input: 0x0000000000000000)
@@ -17,8 +19,45 @@ Total time (s): 0.000712
 Perf: 363.806007 Kips
 ```
 
-## Booting linux under pydrofoil
+A Pydrofoil binary contains an emulator for the 64-bit and for the 32-bit
+variants of the RISC-V model. By default, the 64-bit emulator is used. To chose
+the 32-bit emulator, you can use the `--rv32` commandline option:
 
-This is an example of how to boot a linux kernel using the pdrofoil emulator
+```
+./pydrofoil-riscv --rv32 test/riscv-tests/rv32ui-p-addi.elf
+tohost located at 0x80001000
+entrypoint 0x80000000
+CSR mstatus <- 0x00000000 (input: 0x00000000)
+SUCCESS
+Instructions: 256
+Total time (s): 0.001858
+Perf: 137.782859 Kips
+```
 
-`./pydrofoil-riscv -b riscv/input/rv64-64mb.dtb riscv/input/rv64-linux-4.15.0-gcc-7.2.0-64mb.bbl -l 230000000`
+
+## Booting Linux under Pydrofoil
+
+This is an example of how to boot a Linux kernel using the Pydrofoil emulator:
+
+```
+dtc < os-boot/rv64-64mb.dts > os-boot/rv64-64mb.dtb
+./pydrofoil-riscv -b os-boot/rv64-64mb.dtb os-boot/rv64-linux-4.15.0-gcc-7.2.0-64mb.bbl -l 230000000
+```
+
+This command will run the Linux image that is part of the sail-riscv repo until
+the login prompt.
+
+
+## Commandline Options
+
+The `pydrofoil-riscv` binary accepts the following commandline options:
+
+- `--rv32` run emulator in 32-bit mode (default: 64-bit)
+- `-b/--device-tree-blob <file>` load [device tree blob](https://www.devicetree.org/) from `file`
+- `-l/--inst-limit <limit>` stop execution after `limit` instructions (by
+  default execution is only halted if a test is stopped via the htif device).
+- `--instructions-per-tick <num>` tick the emulated clock every `num`
+  instructions (default: 100).
+- `--verbose` print a detailed trace of every instruction executed
+- `--jit off` turn dynamic binary translation/JIT compilation off
+

--- a/docs/using_pydrofoil.md
+++ b/docs/using_pydrofoil.md
@@ -45,8 +45,18 @@ dtc < os-boot/rv64-64mb.dts > os-boot/rv64-64mb.dtb
 ```
 
 This command will run the Linux image that is part of the sail-riscv repo until
-the login prompt.
+the login prompt. The `dtb` file is a device tree blob that describes the
+emulated hardware to the operating system, it gets generated from a
+human-readable input file with the `dtc` command.
 
+Booting Linux takes a bit less than 4 minutes on Pydrofoil. You can try the
+equivalent command on the standard Sail emulator:
+
+```
+./c_emulator/riscv_sim_RV64 -b os-boot/rv64-64mb.dtb os-boot/rv64-linux-4.15.0-gcc-7.2.0-64mb.bbl -l 230000000 -V
+```
+
+Which takes roughly 75 minutes.
 
 ## Commandline Options
 

--- a/riscv/supportcoderiscv.py
+++ b/riscv/supportcoderiscv.py
@@ -358,7 +358,7 @@ Usage: %s [options] <elf_file>
 --rv32                          run emulator in 32bit mode
 -b/--device-tree-blob <file>    load dtb from file
 -l/--inst-limit <limit>         exit after limit instructions have been executed
---instructions-per-tick <num>   tick the emulated clock every num instructions
+--instructions-per-tick <num>   tick the emulated clock every num instructions (default: 100)
 --verbose                       print a detailed trace of every instruction executed
 --print-kips                    print kip/s every 2**20 instructions
 --jit <options>                 set JIT options


### PR DESCRIPTION
split out build docs between "using pydrofoil" and "working on it" #19 