### PR TITLE
pin the sail riscv repo for now

### DIFF
--- a/.github/workflows/oneshot-script.yml
+++ b/.github/workflows/oneshot-script.yml
@@ -39,6 +39,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: riscv/sail-riscv
+        ref: fea224f5ed4f8eab3654691484bdb5685151fe07
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
the most recent version of the repo requires Sail 0.15, so let's pin a previous commit until we fix #31 