### PR TITLE
four small bitvector jit improvements

### DIFF
--- a/pydrofoil/bitvector.py
+++ b/pydrofoil/bitvector.py
@@ -314,12 +314,17 @@ class SmallBitVector(BitVectorWithSize):
     def replicate(self, i):
         size = self.size()
         if size * i <= 64:
-            res = val = self.val
-            for _ in range(i - 1):
-                res = (res << size) | val
-            return SmallBitVector(size * i, res)
+            return SmallBitVector(size * i, self._replicate(self.val, size, i))
         gbv = GenericBitVector(size, rbigint_fromrarith_int(self.val))
         return gbv.replicate(i)
+
+    @staticmethod
+    @jit.look_inside_iff(lambda val, size, i: jit.isconstant(i))
+    def _replicate(val, size, i):
+        res = val
+        for _ in range(i - 1):
+            res = (res << size) | val
+        return res
 
     def truncate(self, i):
         assert i <= self.size()

--- a/pydrofoil/bitvector.py
+++ b/pydrofoil/bitvector.py
@@ -784,14 +784,25 @@ class BigInteger(Integer):
             other = other.val
             if other == 0:
                 raise ZeroDivisionError
+            if other > 0 and other & (other - 1) == 0 and self.rval.sign >= 0:
+                # can use shift
+                return self.rshift(self._shift_amount(other))
             div, rem = bigint_divrem1(self.rval, other)
             return BigInteger(div)
-
         other = other.tobigint()
         if other.sign == 0:
             raise ZeroDivisionError
         div, rem = bigint_divrem(self.tobigint(), other)
         return BigInteger(div)
+
+    @staticmethod
+    @jit.elidable
+    def _shift_amount(poweroftwo):
+        assert poweroftwo & (poweroftwo - 1) == 0
+        shift = 0
+        while 1 << shift != poweroftwo:
+            shift += 1
+        return shift
 
     def tmod(self, other):
         if isinstance(other, SmallInteger) and int_in_valid_range(other.val):

--- a/pydrofoil/bitvector.py
+++ b/pydrofoil/bitvector.py
@@ -621,7 +621,7 @@ class SmallInteger(Integer):
                 return BigInteger(self.tobigint().int_mul(other.val))
         else:
             assert isinstance(other, BigInteger)
-            return BigInteger(other.rval.int_mul(self.val))
+            return other.mul(self)
 
     def tdiv(self, other):
         # rounds towards zero, like in C, not like in python
@@ -774,6 +774,15 @@ class BigInteger(Integer):
 
     def mul(self, other):
         if isinstance(other, SmallInteger):
+            val = other.val
+            if not val:
+                return SmallInteger(0)
+            if val == 1:
+                return self
+            if val & (val - 1) == 0:
+                # power of two, replace by lshift
+                shift = self._shift_amount(val)
+                return self.lshift(shift)
             return BigInteger(self.rval.int_mul(other.val))
         assert isinstance(other, BigInteger)
         return BigInteger(self.rval.mul(other.rval))

--- a/pydrofoil/supportcode.py
+++ b/pydrofoil/supportcode.py
@@ -549,7 +549,7 @@ def print_real(machine, s, r):
     return ()
 
 def to_real(machine, i):
-    return Real(i.tobigint(), ONERBIGINT)
+    return Real(i.tobigint(), ONERBIGINT, normalized=True)
 
 def undefined_real(machine, _):
     return Real.fromint(12, 19)

--- a/pydrofoil/test/test_supportcode.py
+++ b/pydrofoil/test/test_supportcode.py
@@ -346,7 +346,7 @@ def test_op_int():
         for c2 in bi, si:
             for v1 in [-10, 223, 12311, 0, 1, 2**63-1]:
                 a = c1(v1)
-                for v2 in [-10, 223, 12311, 0, 1, 2**63-1, -2**45]:
+                for v2 in [-10, 223, 12311, 0, 1, 8, 2**63-1, -2**45]:
                     b = c2(v2)
                     assert a.add(b).tolong() == v1 + v2
                     assert a.sub(b).tolong() == v1 - v2

--- a/pydrofoil/test/test_supportcode.py
+++ b/pydrofoil/test/test_supportcode.py
@@ -413,6 +413,18 @@ def test_op_int_div_mod():
             assert c1(-2**63).tdiv(c2(-1)).tolong() == 2 ** 63
             assert c1(-2**63).tmod(c2(-1)).tolong() == 0
 
+def test_shift_amount():
+    for i in range(63):
+        assert BigInteger._shift_amount(2 ** i) == i
+
+def test_mul_optimized(monkeypatch):
+    monkeypatch.setattr(rbigint, "mul", None)
+    monkeypatch.setattr(rbigint, "int_mul", None)
+    res = bi(3 ** 100).mul(si(16))
+    assert res.tolong() == 3 ** 100 * 16
+    res = si(1024).mul(bi(-5 ** 60))
+    assert res.tolong() == -5 ** 60 * 1024
+
 
 def test_op_gv_int():
     for c1 in gbv, bv:


### PR DESCRIPTION
- make replicate not force its argument
- do shifts instead of mul/div if the second argument is a power of two
- make int->real conversion not try to normalize the fraction