### PR TITLE
Block memory improvements

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -56,5 +56,8 @@ jobs:
 
     - name: boot linux
       run: |
-        ./pydrofoil-arm -b 0x80000000,arm/bootloader.bin -b 0x81000000,arm/sail.dtb -b 0x82080000,arm/Image -C cpu.cpu0.RVBAR=0x80000000 -C cpu.has_tlb=0x0  -l 1_000_000 2> /dev/null
+        PYPYLOG=jit-summary:summary ./pydrofoil-arm -b 0x80000000,arm/bootloader.bin -b 0x81000000,arm/sail.dtb -b 0x82080000,arm/Image -C cpu.cpu0.RVBAR=0x80000000 -C cpu.has_tlb=0x0  -l 23_000_000 2> /dev/null
 
+    - name: show jit summary booting
+      run: |
+        cat summary

--- a/arm/supportcodearm.py
+++ b/arm/supportcodearm.py
@@ -21,6 +21,8 @@ def check_file_missing(fn):
 
 
 def get_main(outarm):
+    Globals._pydrofoil_enum_read_ifetch_value = outarm.Enum_zread_kind.zRead_ifetch
+
     Machine = outarm.Machine
 
     driver = jit.JitDriver(

--- a/pydrofoil/mem.py
+++ b/pydrofoil/mem.py
@@ -196,11 +196,13 @@ class BlockMemory(MemBase):
     def __init__(self):
         self.blocks = {}
         self.last_block = None
-        self.last_block_addr = r_uint(0)
+        # invalid block address because higher bits than ADDRESS_BITS_BLOCK are
+        # set
+        self.last_block_addr = r_uint(-1)
 
     def get_block(self, block_addr):
         last_block = self.last_block
-        if last_block is not None and block_addr == self.last_block_addr:
+        if block_addr == self.last_block_addr:
             block = last_block
         else:
             block = self._get_block(block_addr)

--- a/pydrofoil/mem.py
+++ b/pydrofoil/mem.py
@@ -195,16 +195,25 @@ class BlockMemory(MemBase):
 
     def __init__(self):
         self.blocks = {}
+        # we cache two different last blocks, one for instruction fetches, one
+        # for other reads and writes
         self.last_block = None
+        self.last_block_executable = None
         # invalid block address because higher bits than ADDRESS_BITS_BLOCK are
         # set
         self.last_block_addr = r_uint(-1)
+        self.last_block_addr_executable = r_uint(-1)
 
-    def get_block(self, block_addr):
-        last_block = self.last_block
-        if block_addr == self.last_block_addr:
-            block = last_block
+    def get_block(self, block_addr, executable_flag):
+        if executable_flag:
+            if block_addr == self.last_block_addr_executable:
+                return self.last_block_executable
+            block = self._get_block(block_addr)
+            self.last_block_executable = block
+            self.last_block_addr_executable = block_addr
         else:
+            if block_addr == self.last_block_addr:
+                return self.last_block
             block = self._get_block(block_addr)
             self.last_block = block
             self.last_block_addr = block_addr
@@ -218,9 +227,9 @@ class BlockMemory(MemBase):
         return res
 
     @always_inline
-    def _split_addr(self, start_addr, num_bytes):
+    def _split_addr(self, start_addr, num_bytes, executable_flag=False):
         block_addr = start_addr >> self.ADDRESS_BITS_BLOCK
-        block = self.get_block(block_addr)
+        block = self.get_block(block_addr, executable_flag)
         start_addr = start_addr & self.BLOCK_MASK
         block_offset = start_addr >> 3
         inword_addr = start_addr & 0b111
@@ -234,7 +243,7 @@ class BlockMemory(MemBase):
     def _aligned_read(self, start_addr, num_bytes, executable_flag):
         if executable_flag:
             jit.promote(start_addr)
-        block, block_offset, inword_addr, mask = self._split_addr(start_addr, num_bytes)
+        block, block_offset, inword_addr, mask = self._split_addr(start_addr, num_bytes, executable_flag)
         data = block[block_offset]
         if executable_flag:
             jit.promote(data)
@@ -244,7 +253,7 @@ class BlockMemory(MemBase):
         return (data >> (inword_addr * 8)) & mask
 
     def _aligned_write(self, start_addr, num_bytes, value):
-        block, block_offset, inword_addr, mask = self._split_addr(start_addr, num_bytes)
+        block, block_offset, inword_addr, mask = self._split_addr(start_addr, num_bytes, False)
         if num_bytes == 8:
             assert inword_addr == 0
             block[block_offset] = value

--- a/pydrofoil/mem.py
+++ b/pydrofoil/mem.py
@@ -210,14 +210,16 @@ class BlockMemory(MemBase):
         if executable_flag:
             jit.conditional_call(
                 block_addr != self.last_block_addr_executable,
-                self._fetch_and_set_block_executable,
+                BlockMemory._fetch_and_set_block_executable,
+                self,
                 block_addr
             )
             return self.last_block_executable
         else:
             jit.conditional_call(
                 block_addr != self.last_block_addr,
-                self._fetch_and_set_block,
+                BlockMemory._fetch_and_set_block,
+                self,
                 block_addr
             )
             return self.last_block

--- a/pydrofoil/test/test_mem.py
+++ b/pydrofoil/test/test_mem.py
@@ -137,3 +137,37 @@ def test_block_caching():
     assert m.last_block_addr_executable == r_uint(0x200000)
     assert m.last_block_executable is block2
 
+def test_block_caching_platform():
+    from pydrofoil import supportcode, bitvector
+    class FakeMachine(object):
+        class g(object):
+            _pydrofoil_enum_read_ifetch_value = 1
+            mem = TBM()
+    machine = FakeMachine()
+    m = machine.g.mem
+    m.write(r_uint(8), 8, r_uint(0x0102030405060708))
+    block1 = m.last_block
+    m.write(r_uint(0x10000008), 8, r_uint(0xfa11))
+    block2 = m.last_block
+
+    read_kind_normal = 0
+    read_kind_ifetch = machine.g._pydrofoil_enum_read_ifetch_value
+    assert supportcode.platform_read_mem(
+        machine,
+        read_kind_normal,
+        64,
+        bitvector.from_ruint(64, r_uint(8)),
+        bitvector.Integer.fromint(8)).touint() == r_uint(0x0102030405060708)
+    assert m.last_block_addr == r_uint(0)
+    assert m.last_block is block1
+
+    assert supportcode.platform_read_mem(
+        machine,
+        read_kind_ifetch,
+        64,
+        bitvector.from_ruint(64, r_uint(0x10000008)),
+        bitvector.Integer.fromint(8)).touint() == r_uint(0xfa11)
+    assert m.last_block_addr == r_uint(0)
+    assert m.last_block is block1
+    assert m.last_block_addr_executable == r_uint(0x200000)
+    assert m.last_block_executable is block2

--- a/pydrofoil/test/test_supportcode.py
+++ b/pydrofoil/test/test_supportcode.py
@@ -1370,6 +1370,7 @@ def test_real_sqrt_hypothesis(a):
 class FakeMachine(object):
     def __init__(self):
         self.g = supportcode.Globals()
+        self._pydrofoil_enum_read_ifetch_value = 1
 
 def test_read_write_mem():
     m = FakeMachine()


### PR DESCRIPTION
try to make the block memory implementation more friendly to the way it's used in the ARM model:
- two different cached blocks for ifetch and everything else
- don't generate bridges for whether the block is cached or not, use `jit.conditional_call` instead