### PR TITLE
set html_context and html_baseurl as recommended by readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import datetime
+year = datetime.now().year
+
 project = 'Pydrofoil'
-copyright = '2023, Pydrofoil Contributors'
+copyright = f'2023-{year}, Pydrofoil Contributors'
 author = 'Pydrofoil Contributors'
 
 # -- General configuration ---------------------------------------------------
@@ -28,3 +32,13 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_theme = 'furo'
 html_static_path = ['_static']
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_context = {}
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 import os
-import datetime
+from datetime import datetime
 year = datetime.now().year
 
 project = 'Pydrofoil'


### PR DESCRIPTION
As recommended in the upcoming changes [for readthedocs](https://about.readthedocs.com/blog/2024/07/addons-by-default/)

Also update the copyright range using `datetime.now().year`. See numpy/numpy#26834 for some justification for maintaining a range.