### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ALL: pydrofoil-riscv
 
 .PHONY: pydrofoil-riscv
 pydrofoil-riscv: pypy_binary/bin/python pypy2/rpython/bin/rpython pydrofoil/softfloat/SoftFloat-3e/build/Linux-RISCV-GCC/softfloat.o ## Build the pydrofoil RISC-V emulator
-	pkg-config libffi # if this fails, libffi development headers arent installed
+	pkg-config libffi # if this fails, libffi development headers aren't installed
 	PYTHONPATH=. pypy_binary/bin/python ${RPYTHON_DIR}/bin/rpython -Ojit --output=pydrofoil-riscv riscv/targetriscv.py
 
 pydrofoil-test: pypy_binary/bin/python pypy2/rpython/bin/rpython pydrofoil/softfloat/SoftFloat-3e/build/Linux-RISCV-GCC/softfloat.o ## Run the pydrofoil implementation-level unit tests

--- a/docs/captain_s_log.md
+++ b/docs/captain_s_log.md
@@ -55,7 +55,7 @@ Developer Log
 22.06.2022:
 ==
 - participants: CF, JW, NR
-- introdution to the whole stack of layers for Nico
+- introduction to the whole stack of layers for Nico
 
 21.06.2022:
 ==

--- a/docs/sail_notes.md
+++ b/docs/sail_notes.md
@@ -9,7 +9,7 @@ More about SAIL: https://github.com/rems-project/sail
 
 Semicolon:
 ==
-Instruction seperator
+Instruction separator
 
 Example:
 ```
@@ -50,7 +50,7 @@ Normal Functions:
 ==
 Argument types after colon and return type after ->. 
 Body after =.
-Brackets used when body contains more than one statment. 
+Brackets used when body contains more than one statement. 
 Last expression is the return value.
 
 Example:
@@ -63,7 +63,7 @@ function compute_value(a : bits(1), op : arithmetic_op) -> bits(16) = {
 
 Functions Signature Declaration:
 ==
-The declaration of a function can be moved into a seperate line using val.
+The declaration of a function can be moved into a separate line using val.
 
 Example:
 ```

--- a/pydrofoil/ir.py
+++ b/pydrofoil/ir.py
@@ -4014,7 +4014,7 @@ def should_inline(graph, model_specific_should_inline=None):
 def topo_order(graph):
     order = list(graph.iterblocks()) # dfs
 
-    # do a (slighly bad) topological sort
+    # do a (slightly bad) topological sort
     incoming = defaultdict(set)
     for block in order:
         for nextblock in block.next.next_blocks():

--- a/pydrofoil/test/test_mem.py
+++ b/pydrofoil/test/test_mem.py
@@ -17,7 +17,7 @@ def test_mem_write_read(memcls):
     mem = memcls()
     assert mem.read(r_uint(1), 1) == 0
     addresses = range(100) + [TBM.BLOCK_MASK + i for i in range(-100, 100)]
-    # cleck little endianness
+    # check little endianness
     mem.write(r_uint(8), 8, r_uint(0x0102030405060708))
     assert mem.read(r_uint(8), 1) == r_uint(0x08)
     assert mem.read(r_uint(9), 1) == r_uint(0x07)

--- a/pydrofoil/test/test_supportcode.py
+++ b/pydrofoil/test/test_supportcode.py
@@ -1551,7 +1551,7 @@ def test_sparse_hypothesis_truncate(data):
 @given(strategies.data())
 def test_sparse_hypothesis_vector_subrange(data):
     bitwidth = data.draw(strategies.integers(65, 10000))
-    # TODO m- n + 1 = 64 wont work
+    # TODO m- n + 1 = 64 won't work
     lower = data.draw(strategies.integers(0, 62))
     upper = data.draw(strategies.integers(lower, 62))
     value = data.draw(strategies.integers(0, 2**63 - 1))

--- a/run_riscv_tests.py
+++ b/run_riscv_tests.py
@@ -28,7 +28,7 @@ def run(cmd, fn, test_cases):
         print stdout
         print stderr
     else:
-        print "SUCESS"
+        print "SUCCESS"
     p.stdout.close()
     p.stderr.close()
 


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=ans,asign,fle,ressize,sie,zuser --skip="*/softfloat/*,*.ir,*.json"`
```
./Makefile:9: arent ==> aren't
./run_riscv_tests.py:31: SUCESS ==> SUCCESS
./docs/captain_s_log.md:58: introdution ==> introduction
./docs/sail_notes.md:12: seperator ==> separator
./docs/sail_notes.md:53: statment ==> statement
./docs/sail_notes.md:66: seperate ==> separate
./pydrofoil/ir.py:4017: slighly ==> slightly
./pydrofoil/test/test_mem.py:20: cleck ==> check
./pydrofoil/test/test_supportcode.py:1554: wont ==> won't
```
% `codespell --ignore-words-list=ans,asign,fle,ressize,sie,zuser --skip="*/softfloat/*,*.ir,*.json" --write-changes`