### PR TITLE
Fix pypy bug fallout

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v4
@@ -32,6 +32,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "pypy-2.7-v7.3.10"
+
+    - name: Download PyPy nightly and install dependencies
+      run: |
+        make pypy_binary_nightly
+        make pypy2/rpython/bin/rpython
 
     - name: Restore cached IR
       id: cache-ir-restore
@@ -58,12 +63,10 @@ jobs:
 
     - name: Run ARM unit test
       run: |
-        make pypy_binary/bin/python
         PYPY_GC_MAX=12GB PYTHONPATH=.:pypy2 ./pypy_binary/bin/python pypy2/pytest.py -vs arm/
 
     - name: build ARM
       run: |
-        make pypy_binary/bin/python pypy2/rpython/bin/rpython arm/armv9.ir
         PYTHONPATH=. pypy_binary/bin/python pypy2/rpython/bin/rpython -Ojit --translation-withsmallfuncsets=0 --output=pydrofoil-arm arm/targetarm.py --no-arm-regen
 
     - name: boot linux

--- a/.github/workflows/cheriot.yml
+++ b/.github/workflows/cheriot.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
 
     - name: install dependencies and create virtualenv
       run: |
-        make pypy_binary/bin/python
+        make pypy_binary_nightly
         make pypy2/rpython/bin/rpython
 
     - name: install opam

--- a/.github/workflows/pydrofoil.yml
+++ b/.github/workflows/pydrofoil.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
     - name: install dependencies and create virtualenv
       run: |
-        make pypy_binary/bin/python
+        make pypy_binary_nightly
         make pypy2/rpython/bin/rpython
 
     - name: Test with pytest
@@ -47,7 +47,7 @@ jobs:
         ./pypy_binary/bin/python -X faulthandler pypy2/pytest.py -vs pydrofoil/ riscv/
 
     - name: Test Coverage for Bitvectors, Integers and Reals
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         ./pypy_binary/bin/python -m coverage run pypy2/pytest.py --hypothesis-profile=coverage -v pydrofoil/test/test_supportcode.py pydrofoil/test/test_real.py
         ./pypy_binary/bin/python -m coverage report --include=pydrofoil/bitvector.py --fail-under=99 -m

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,16 @@ pypy_binary/bin/python:  ## Download a PyPy binary
 	./pypy_binary/bin/python -m ensurepip
 	./pypy_binary/bin/python -mpip install rply "hypothesis<4.40" junit_xml coverage==5.5
 
+.PHONY: pypy_binary_nightly
+pypy_binary_nightly:  ## Download a nightly PyPy binary (instead of stable)
+	rm -rf pypy_binary
+	mkdir pypy_binary
+	python3 get_pypy_to_download.py --nightly
+	tar -C pypy_binary --strip-components=1 -xf pypy.tar.bz2
+	rm pypy.tar.bz2
+	./pypy_binary/bin/python -m ensurepip
+	./pypy_binary/bin/python -mpip install rply "hypothesis<4.40" junit_xml coverage==5.5
+
 pypy2/rpython/bin/rpython: ## Clone the PyPy submodule
 	git submodule update --init --depth 1
 

--- a/get_pypy_to_download.py
+++ b/get_pypy_to_download.py
@@ -4,11 +4,15 @@ Use the platform.uname and the versions.json from downloads.python.org to find
 the name of the latests pypy2.7 for this platform. Print it out on stdout
 """
 
+import sys
 import json
 from urllib import request, error
 import platform
 import tarfile
 import io
+
+
+want_nightly = "--nightly" in sys.argv
 
 response = request.urlopen('https://downloads.python.org/pypy/versions.json')
 if not (response.getcode(), 200):
@@ -23,17 +27,20 @@ def lookup_arch(machine):
     else:
         return machine
 
+found_versions = []
 for d in data:
-    if d['stable'] is True and "2.7" in d["python_version"]:
+    if d['stable'] == (not want_nightly) and "2.7" in d["python_version"]:
         for f in d["files"]:
             if f["arch"] == lookup_arch(uname.machine) and f["platform"] == uname.system.lower():
-                download = f["download_url"]
+                found_versions.append((d, f))
                 break
         else:
             raise RuntimeError(
                 f"No known stable PyPy2.7 build for {uname.machine}-{uname.system}"
             )
-        break
-else:
-    raise RuntimeError(f"No known stable PyPy2.7 build???")
+if want_nightly:
+    found_versions = [d for d in found_versions if d[0]['pypy_version'] == 'nightly']
+found_versions.sort(key=lambda x: x[0].get('date', None))
+
+download = found_versions[-1][1]["download_url"]
 request.urlretrieve(download, filename="pypy.tar.bz2")

--- a/pydrofoil/bitvector.py
+++ b/pydrofoil/bitvector.py
@@ -1785,14 +1785,20 @@ class BigInteger(Integer):
         return shift
 
     def tmod(self, other):
-        jit.jit_debug("BigInteger.tmod")
         if isinstance(other, SmallInteger) and int_in_valid_range(other.val):
             other = other.val
             if other == 0:
                 raise ZeroDivisionError
+            if self.sign == 0:
+                return INT_ZERO
+            if other > 0 and other & (other - 1) == 0 and self.sign >= 0:
+                # can use mask
+                return Integer.fromint(intmask(self.data[0] & (other - 1)))
+            jit.jit_debug("BigInteger.tmod")
             div, rem = bigint_divrem1(self.tobigint(), other)
             return SmallInteger(rem)
 
+        jit.jit_debug("BigInteger.tmod")
         other = other.tobigint()
         if other.get_sign() == 0:
             raise ZeroDivisionError

--- a/pydrofoil/ir.py
+++ b/pydrofoil/ir.py
@@ -1454,6 +1454,8 @@ class GraphPage(BaseGraphPage):
 
 # some simple graph simplifications
 
+class CantFold(Exception):
+    pass
 
 TIMINGS = defaultdict(float)
 COUNTS = defaultdict(int)
@@ -2434,6 +2436,8 @@ class LocalOptimizer(BaseOptimizer):
                 return None
         try:
             res = func("constfolding", *runtimeargs)
+        except CantFold:
+            return None # silent
         except (Exception, AssertionError) as e:
             print "generict const-folding failed", name, op, "with error", e, "arguments", args
             return None

--- a/pydrofoil/supportcode.py
+++ b/pydrofoil/supportcode.py
@@ -518,21 +518,24 @@ def count_leading_zeros(machine, bv):
 @purefunction
 def pack_smallfixedbitvector(machine, width, val):
     if not objectmodel.we_are_translated() and machine == "constfolding":
-        raise TypeError("can't constfold yet")
+        from pydrofoil.ir import CantFold
+        raise CantFold
     return width, val, None
 
 @objectmodel.always_inline
 @purefunction
 def pack_machineint(machine, val):
     if not objectmodel.we_are_translated() and machine == "constfolding":
-        raise TypeError("can't constfold yet")
+        from pydrofoil.ir import CantFold
+        raise CantFold
     return val, None
 
 @objectmodel.always_inline
 @purefunction
 def packed_field_cast_smallfixedbitvector(machine, targetwidth, (width, val, data)):
     if not objectmodel.we_are_translated() and machine == "constfolding":
-        raise TypeError("can't constfold yet")
+        from pydrofoil.ir import CantFold
+        raise CantFold
     assert width == targetwidth
     return val
 
@@ -541,7 +544,8 @@ def packed_field_cast_smallfixedbitvector(machine, targetwidth, (width, val, dat
 def packed_field_int_to_int64(machine, (val, data)):
     # equivalent to Integer.unpack(val, data).toint()
     if not objectmodel.we_are_translated() and machine == "constfolding":
-        raise TypeError("can't constfold yet")
+        from pydrofoil.ir import CantFold
+        raise CantFold
     if data is None:
         return val
     return bitvector.BigInteger._sign_and_data_toint(val, data)


### PR DESCRIPTION
the recent pypy release has a JIT bug that caused pydrofoil tests to segfault. the bug is now fixed, but it means we need to switch to running pydrofoil ci on nightly pypy builds.