### PR TITLE
small plugin improvements

### DIFF
--- a/docs/scripting-api.md
+++ b/docs/scripting-api.md
@@ -247,7 +247,7 @@ t1 = time.time()
 try:
     for i in range(instructions):
         cpu.step()
-        histogram_pcs[str(cpu.read_register("pc"))] += 1
+        histogram_pcs[cpu.read_register("pc")] += 1
         dis = cpu.disassemble_last_instruction()
         histogram_instructions[dis] += 1
         histogram_mnemonic[dis.split()[0]] += 1

--- a/pydrofoil/makecode.py
+++ b/pydrofoil/makecode.py
@@ -938,7 +938,7 @@ class __extend__(parse.Function):
             functyp = codegen.globalnames[self.name].typ
             for graph2, graph2typ in split_completely(graph, self, functyp, codegen):
                 codegen.add_global(graph2.name, graph2.name, graph2typ)
-                codegen.add_graph(graph2, self.emit_regular_function, graph2.name)
+                codegen.add_graph(graph2, self.emit_regular_function, graph2.name, export_to_python=False)
         else:
             if usefully_specializable(graph):
                 codegen.specialization_functions[self.name] = Specializer(graph, codegen)

--- a/riscv/pypymodule/app_helpers.py
+++ b/riscv/pypymodule/app_helpers.py
@@ -9,3 +9,6 @@ def repr_union(union):
     fields = [repr(x) for x in union]
     fields = ", ".join(fields)
     return f"{union.__class__.__name__}({fields})"
+
+def hash_union(union):
+    return hash(tuple(union)) ^ 0x12482abf

--- a/riscv/pypymodule/interp_plugin.py
+++ b/riscv/pypymodule/interp_plugin.py
@@ -811,6 +811,10 @@ class __extend__(BitVector):
         """ Sign-extend the bitvector to width target_size. """
         return self.sign_extend(target_size)
 
+    def descr_index(self, space):
+        """ Interpret the bitvector as an integer """
+        return self.descr_unsigned(space)
+
 
 @unwrap_spec(width=int, value=r_uint)
 def bitvector_descr_new(w_type, space, width, value):
@@ -839,6 +843,8 @@ BitVector.typedef = TypeDef("bitvector",
     __matmul__ = interp2app(BitVector.descr_matmul),
 
     __invert__ = interp2app(BitVector.descr_invert),
+
+    __index__ = interp2app(BitVector.descr_index),
 
     signed = interp2app(BitVector.descr_signed),
     unsigned = interp2app(BitVector.descr_unsigned),

--- a/riscv/pypymodule/interp_plugin.py
+++ b/riscv/pypymodule/interp_plugin.py
@@ -21,10 +21,10 @@ def _patch_machineclasses(machinecls64=None, machinecls32=None, space=None):
     if "machinecls64" in globals():
         return
     if machinecls64 is None:
-        mod64 = _make_code(True)
+        mod64 = _make_code(True, export_everything=True)
         machinecls64 = supportcoderiscv.get_main(mod64, True)._machinecls
     if machinecls32 is None:
-        mod32 = _make_code(False)
+        mod32 = _make_code(False, export_everything=True)
         machinecls32 = supportcoderiscv.get_main(mod32, False)._machinecls
     globals()["machinecls64"] = machinecls64
     globals()["machinecls32"] = machinecls32

--- a/riscv/pypymodule/interp_plugin.py
+++ b/riscv/pypymodule/interp_plugin.py
@@ -157,6 +157,7 @@ def invent_python_cls_union(space, w_mod, type_info, machinecls):
         __len__=_make_union_len(space, machinecls, cls),
         __repr__=_make_union_repr(space, machinecls, cls),
         __eq__=_make_union_eq(space, machinecls, cls),
+        __hash__=_make_union_hash(space, machinecls, cls),
         sail_type = sail_type
     )
     cls.typedef.acceptable_as_base_class = False
@@ -242,6 +243,11 @@ def _make_union_eq(space, machinecls, basecls):
             return space.w_NotImplemented
         return space.newbool(self.eq(w_other))
     return _interp2app_unique_name_as_method(descr_eq, machinecls, basecls)
+
+def _make_union_hash(space, machinecls, basecls):
+    def descr_hash(self, space):
+        return app_hash_union(space, self)
+    return _interp2app_unique_name_as_method(descr_hash, machinecls, basecls)
 
 def _make_union_getitem(space, machinecls, subcls, sail_type):
     unroll_get_fields = unrolling_iterable(
@@ -725,7 +731,8 @@ class __extend__(BitVector):
             return space.newint(0)
 
     def descr_eq(self, space, w_other):
-        w_other = self._pypy_coerce(space, w_other)
+        if not isinstance(w_other, BitVector):
+            w_other = self._pypy_coerce(space, w_other)
         if w_other is None:
             return space.w_NotImplemented
         if self.size() != w_other.size():
@@ -815,6 +822,9 @@ class __extend__(BitVector):
         """ Interpret the bitvector as an integer """
         return self.descr_unsigned(space)
 
+    def descr_hash(self, space):
+        return space.newint(self.tobigint().hash() ^ self.size())
+
 
 @unwrap_spec(width=int, value=r_uint)
 def bitvector_descr_new(w_type, space, width, value):
@@ -845,6 +855,7 @@ BitVector.typedef = TypeDef("bitvector",
     __invert__ = interp2app(BitVector.descr_invert),
 
     __index__ = interp2app(BitVector.descr_index),
+    __hash__ = interp2app(BitVector.descr_hash),
 
     signed = interp2app(BitVector.descr_signed),
     unsigned = interp2app(BitVector.descr_unsigned),
@@ -865,3 +876,4 @@ with open(appfile, "r") as f:
 app = applevel(content, filename=__file__)
 app_repr_union = app.interphook('repr_union')
 app_repr_struct = app.interphook('repr_struct')
+app_hash_union = app.interphook('hash_union')

--- a/riscv/pypymodule/interp_types.py
+++ b/riscv/pypymodule/interp_types.py
@@ -10,7 +10,7 @@ from pydrofoil.types import *
 class __extend__(Type):
     _attrs_ = []
 
-Type.typedef = TypeDef("_pydrofoil.types.SailType",
+Type.typedef = TypeDef("_pydrofoil.sailtypes.SailType",
     __doc__ = """Instances of (subclasses of) this class represents a Sail
                  type. """,
 )
@@ -22,7 +22,7 @@ class __extend__(Union):
                      for index, name in enumerate(self.names_list)]
         return space.newlist(res_w)
 
-Union.typedef = TypeDef("_pydrofoil.types.Union", Type.typedef,
+Union.typedef = TypeDef("_pydrofoil.sailtypes.Union", Type.typedef,
     name = interp_attrproperty("demangled_name", Union, "the name of the union type", "newtext"),
     constructors = GetSetProperty(Union.descr_get_constructors),
 )
@@ -34,7 +34,7 @@ class __extend__(Enum):
                     for element in self.elements_list]
         return space.newlist(res_w)
 
-Enum.typedef = TypeDef("_pydrofoil.types.Enum", Type.typedef,
+Enum.typedef = TypeDef("_pydrofoil.sailtypes.Enum", Type.typedef,
     name = interp_attrproperty("demangled_name", Enum, "the name of the enum type", "newtext"),
     elements = GetSetProperty(Enum.descr_get_elements),
 )
@@ -45,7 +45,7 @@ class __extend__(RegularStruct):
         res_w = [space.newtuple2(space.newtext(name), self.typs_list[index])
                      for index, name in enumerate(self.names_list)]
         return space.newlist(res_w)
-RegularStruct.typedef = TypeDef("_pydrofoil.types.Struct", Type.typedef,
+RegularStruct.typedef = TypeDef("_pydrofoil.sailtypes.Struct", Type.typedef,
     name = interp_attrproperty("demangled_name", RegularStruct, "the name of the struct type", "newtext"),
     fields = GetSetProperty(RegularStruct.descr_get_fields),
 )
@@ -63,7 +63,7 @@ class __extend__(TupleStruct):
             raise oefmt(space.w_IndexError, "index out of range")
         return self.typs_list[index]
 
-TupleStruct.typedef = TypeDef("_pydrofoil.types.Tuple", Type.typedef,
+TupleStruct.typedef = TypeDef("_pydrofoil.sailtypes.Tuple", Type.typedef,
     __len__ = interp2app(TupleStruct.descr_len),
     __getitem__ = interp2app(TupleStruct.descr_getitem),
 )
@@ -71,21 +71,21 @@ TupleStruct.typedef.acceptable_as_base_class = False
 
 class __extend__(Ref):
     pass
-Ref.typedef = TypeDef("_pydrofoil.types.Ref", Type.typedef,
+Ref.typedef = TypeDef("_pydrofoil.sailtypes.Ref", Type.typedef,
     of = interp_attrproperty_w("typ", Ref)
 )
 Ref.typedef.acceptable_as_base_class = False
 
 class __extend__(Vec):
     pass
-Vec.typedef = TypeDef("_pydrofoil.types.Vec", Type.typedef,
+Vec.typedef = TypeDef("_pydrofoil.sailtypes.Vec", Type.typedef,
     of = interp_attrproperty_w("typ", Vec)
 )
 Vec.typedef.acceptable_as_base_class = False
 
 class __extend__(FVec):
     pass
-FVec.typedef = TypeDef("_pydrofoil.types.FVec", Type.typedef,
+FVec.typedef = TypeDef("_pydrofoil.sailtypes.FVec", Type.typedef,
     of = interp_attrproperty_w("typ", FVec),
     length = interp_attrproperty("number", FVec, None, "newint"),
 )
@@ -96,7 +96,7 @@ class __extend__(Function):
         return space.newlist(self.argument_list[:])
     def descr_get_result(self, space):
         return self.restype
-Function.typedef = TypeDef("_pydrofoil.types.Function", Type.typedef,
+Function.typedef = TypeDef("_pydrofoil.sailtypes.Function", Type.typedef,
     arguments = GetSetProperty(Function.descr_get_arguments),
     result = GetSetProperty(Function.descr_get_result),
 )
@@ -104,69 +104,69 @@ Function.typedef.acceptable_as_base_class = False
 
 class __extend__(List):
     pass
-List.typedef = TypeDef("_pydrofoil.types.List", Type.typedef,
+List.typedef = TypeDef("_pydrofoil.sailtypes.List", Type.typedef,
 )
 List.typedef.acceptable_as_base_class = False
 
 class __extend__(NullType):
     pass
-NullType.typedef = TypeDef("_pydrofoil.types.Null", Type.typedef,
+NullType.typedef = TypeDef("_pydrofoil.sailtypes.Null", Type.typedef,
 )
 NullType.typedef.acceptable_as_base_class = False
 
 class __extend__(SmallFixedBitVector):
     pass
-SmallFixedBitVector.typedef = TypeDef("_pydrofoil.types.SmallFixedBitVector", Type.typedef,
+SmallFixedBitVector.typedef = TypeDef("_pydrofoil.sailtypes.SmallFixedBitVector", Type.typedef,
     width = interp_attrproperty("width", SmallFixedBitVector, "the width of the bitvector", "newint"),
 )
 SmallFixedBitVector.typedef.acceptable_as_base_class = False
 
 class __extend__(BigFixedBitVector):
     pass
-BigFixedBitVector.typedef = TypeDef("_pydrofoil.types.BigFixedBitVector", Type.typedef,
+BigFixedBitVector.typedef = TypeDef("_pydrofoil.sailtypes.BigFixedBitVector", Type.typedef,
     width = interp_attrproperty("width", BigFixedBitVector, "the width of the bitvector", "newint"),
 )
 BigFixedBitVector.typedef.acceptable_as_base_class = False
 
 class __extend__(GenericBitVector):
     pass
-GenericBitVector.typedef = TypeDef("_pydrofoil.types.GenericBitVector", Type.typedef,
+GenericBitVector.typedef = TypeDef("_pydrofoil.sailtypes.GenericBitVector", Type.typedef,
 )
 GenericBitVector.typedef.acceptable_as_base_class = False
 
 class __extend__(MachineInt):
     pass
-MachineInt.typedef = TypeDef("_pydrofoil.types.MachineInt", Type.typedef,
+MachineInt.typedef = TypeDef("_pydrofoil.sailtypes.MachineInt", Type.typedef,
 )
 MachineInt.typedef.acceptable_as_base_class = False
 
 class __extend__(Int):
     pass
-Int.typedef = TypeDef("_pydrofoil.types.Int", Type.typedef,
+Int.typedef = TypeDef("_pydrofoil.sailtypes.Int", Type.typedef,
 )
 Int.typedef.acceptable_as_base_class = False
 
 class __extend__(Bool):
     pass
-Bool.typedef = TypeDef("_pydrofoil.types.Bool", Type.typedef,
+Bool.typedef = TypeDef("_pydrofoil.sailtypes.Bool", Type.typedef,
 )
 Bool.typedef.acceptable_as_base_class = False
 
 class __extend__(Unit):
     pass
-Unit.typedef = TypeDef("_pydrofoil.types.Unit", Type.typedef,
+Unit.typedef = TypeDef("_pydrofoil.sailtypes.Unit", Type.typedef,
 )
 Unit.typedef.acceptable_as_base_class = False
 
 class __extend__(String):
     pass
-String.typedef = TypeDef("_pydrofoil.types.String", Type.typedef,
+String.typedef = TypeDef("_pydrofoil.sailtypes.String", Type.typedef,
 )
 String.typedef.acceptable_as_base_class = False
 
 class __extend__(Real):
     pass
-Real.typedef = TypeDef("_pydrofoil.types.Real", Type.typedef,
+Real.typedef = TypeDef("_pydrofoil.sailtypes.Real", Type.typedef,
 )
 Real.typedef.acceptable_as_base_class = False
 

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -399,3 +399,7 @@ def test_append():
     b1 = _pydrofoil.bitvector(4, 0b1100)
     assert b0 @ b1 == _pydrofoil.bitvector(10, 0b1101001100)
 
+def test_bitvector_to_int():
+    b0 = _pydrofoil.bitvector(6, 7)
+    assert list(range(10))[b0] == 7
+    assert int(b0) == 7

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -312,6 +312,10 @@ def test_call_encdec_backwards():
     res = m.lowlevel.assembly_forwards(ast)
     assert res == 'andi a5, zero, 0x0'
 
+def test_next_functions_arent_exposed():
+    m = _pydrofoil.RISCV64()
+    assert not hasattr(m.lowlevel, 'encdec_backwards_next_0')
+
 def test_packed_struct_fields():
     m = _pydrofoil.RISCV64()
     res = m.lowlevel.read_ram_specialized_o_o_o_False("Read_plain",2,3,4)

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -205,6 +205,16 @@ def test_union_enum():
     s = SomeReadKind('Read_plain')
     assert s[0] == 'Read_plain'
 
+def test_union_hash():
+    m = _pydrofoil.RISCV64()
+    ast1 = m.types.ADDIW(2045, 3, 5)
+    ast1a = m.types.ADDIW(2045, 3, 5)
+    ast2 = m.types.ADDIW(2045, 3, 12)
+    assert ast1 == ast1a
+    assert ast1 != ast2
+    assert hash(ast1) == hash(ast1a)
+    assert hash(ast1) != hash(ast2)
+
 #def test_union_pattern_matching():
 #    m = _pydrofoil.RISCV64()
 #    ADDIW = m.types.ADDIW
@@ -403,3 +413,18 @@ def test_bitvector_to_int():
     b0 = _pydrofoil.bitvector(6, 7)
     assert list(range(10))[b0] == 7
     assert int(b0) == 7
+
+def test_bitvector_hash():
+    m = _pydrofoil.RISCV64()
+    val = 0b110100
+    bv1 = _pydrofoil.bitvector(6, val)
+    bv1a = _pydrofoil.bitvector(6, val)
+    bv2 = _pydrofoil.bitvector(7, val)
+    bv3 = _pydrofoil.bitvector(6, 0b110101)
+    assert bv1 == bv1a
+    assert bv1 != bv2
+    assert bv1 != bv3
+    assert hash(bv1) == hash(bv1a)
+    assert hash(bv1) != hash(bv2)
+    assert hash(bv1) != hash(bv3)
+

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -334,6 +334,25 @@ def test_sailfunction_doc():
     m = _pydrofoil.RISCV64()
     doc = m.lowlevel.encdec_backwards.__doc__
     assert "encdec_backwards" in doc
+    doc = m.lowlevel.aes_mixcolumn_inv.__doc__
+    assert doc == '''\
+Sail function
+aes_mixcolumn_inv
+/* 32-bit to 32-bit AES inverse MixColumn */
+val aes_mixcolumn_inv : bits(32) -> bits(32)
+function aes_mixcolumn_inv(x) = {
+  let s0 : bits (8) = x[ 7.. 0];
+  let s1 : bits (8) = x[15.. 8];
+  let s2 : bits (8) = x[23..16];
+  let s3 : bits (8) = x[31..24];
+  let b0 : bits (8) = gfmul(s0, 0xE) ^ gfmul(s1, 0xB) ^ gfmul(s2, 0xD) ^ gfmul(s3, 0x9);
+  let b1 : bits (8) = gfmul(s0, 0x9) ^ gfmul(s1, 0xE) ^ gfmul(s2, 0xB) ^ gfmul(s3, 0xD);
+  let b2 : bits (8) = gfmul(s0, 0xD) ^ gfmul(s1, 0x9) ^ gfmul(s2, 0xE) ^ gfmul(s3, 0xB);
+  let b3 : bits (8) = gfmul(s0, 0xB) ^ gfmul(s1, 0xD) ^ gfmul(s2, 0x9) ^ gfmul(s3, 0xE);
+  b3 @ b2 @ b1 @ b0 /* Return value */
+}
+'''
+
 
 def test_sailfunction_type():
     m = _pydrofoil.RISCV64()

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -316,6 +316,10 @@ def test_next_functions_arent_exposed():
     m = _pydrofoil.RISCV64()
     assert not hasattr(m.lowlevel, 'encdec_backwards_next_0')
 
+def test_inlined_functions_are_exposed():
+    m = _pydrofoil.RISCV64()
+    assert m.lowlevel.bit_to_bool(0) is False
+
 def test_packed_struct_fields():
     m = _pydrofoil.RISCV64()
     res = m.lowlevel.read_ram_specialized_o_o_o_False("Read_plain",2,3,4)

--- a/riscv/targetriscv.py
+++ b/riscv/targetriscv.py
@@ -22,13 +22,13 @@ def should_inline(name):
     if "request_is_exclusive" in name:
         return True
 
-def _make_code(rv64=True):
+def _make_code(rv64=True, export_everything=False):
     print "making python code"
     with open(riscvirs[rv64], "rb") as f:
         s = f.read()
     support_code = "from riscv import supportcoderiscv as supportcode"
     entrypoints = "ztick_clock ztick_platform zinit_model zstep zext_decode".split()
-    res = parse_and_make_code(s, support_code, {'zPC', 'znextPC', 'zMisa_chunk_0', 'zcur_privilege', 'zMstatus_chunk_0', }, entrypoints=entrypoints, should_inline=should_inline)
+    res = parse_and_make_code(s, support_code, {'zPC', 'znextPC', 'zMisa_chunk_0', 'zcur_privilege', 'zMstatus_chunk_0', }, entrypoints=entrypoints, should_inline=should_inline, export_everything=export_everything)
     with open(outriscvpys[rv64], "w") as f:
         f.write(res)
     if rv64:


### PR DESCRIPTION
- expose more Sail functions to Python
- extract the sail source code for some of the functions and put it into the help text
- make bitvectors and union objects hashable
- allow conversions of bitvectors to ints