### PR TITLE
Pypy plugin reset vector

### DIFF
--- a/riscv/pypymodule/interp_plugin.py
+++ b/riscv/pypymodule/interp_plugin.py
@@ -611,6 +611,14 @@ class MachineAbstractBase(object):
     def descr_get_lowlevel(self, space):
         return self.W_Lowlevel(space, self)
 
+    @unwrap_spec(start=r_uint, size=r_uint)
+    def descr_set_sail_memory_bounds(self, space, start, size):
+        if start + size < start:
+            raise oefmt(space.w_ValueError, "end point of memory bounds outside of 64-bit")
+        self.machine.g.rv_ram_base = start
+        self.machine.g.rv_ram_size = size
+
+
 
 class MemoryObserver(mem_mod.MemBase):
     _immutable_fields_ = ['wrapped']
@@ -728,6 +736,7 @@ W_RISCV64.typedef = TypeDef("_pydrofoil.RISCV64",
     disassemble_last_instruction = interp2app(W_RISCV64.disassemble_last_instruction),
     types = GetSetProperty(W_RISCV64.descr_get_types),
     lowlevel = GetSetProperty(W_RISCV64.descr_get_lowlevel),
+    _set_sail_memory_bounds = interp2app(W_RISCV64.descr_set_sail_memory_bounds),
 )
 
 
@@ -764,6 +773,7 @@ W_RISCV32.typedef = TypeDef("_pydrofoil.RISCV32",
     disassemble_last_instruction = interp2app(W_RISCV32.disassemble_last_instruction),
     types = GetSetProperty(W_RISCV32.descr_get_types),
     lowlevel = GetSetProperty(W_RISCV32.descr_get_lowlevel),
+    _set_sail_memory_bounds = interp2app(W_RISCV32.descr_set_sail_memory_bounds),
 )
 
 # bitvector support

--- a/riscv/pypymodule/interp_plugin.py
+++ b/riscv/pypymodule/interp_plugin.py
@@ -465,9 +465,11 @@ class MachineAbstractBase(object):
             observer.wrapped = mem
         if elf is not None:
             entry = load_sail(space, self.machine, elf)
+            write_reset_vector = True
         else:
             entry = self.machine.g.rv_ram_base
-        self.reset_pc = init_sail(space, self.machine, entry)
+            write_reset_vector = False
+        self.reset_pc = init_sail(space, self.machine, entry, write_reset_vector)
         self.machine.set_pc(self.reset_pc)
         self.machine.g._init_ranges()
 

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -509,6 +509,24 @@ def test_step_intercept_mem():
     assert mem[_pydrofoil.bitvector(64, 0x0000000010000000)] == _pydrofoil.bitvector(64, 0x34202F7304C0006F)
     assert cpu.memory_info() == [(0x1000, 0x80001047)]
 
+def test_dont_do_reset_vector_without_elf():
+    mem = {}
+    def read(addr):
+        return mem.get(addr, _pydrofoil.bitvector(64, 0))
+    def write(addr, value):
+        mem[addr] = value
+
+    callbacks = _pydrofoil.Callbacks(mem_read8_intercept=read, mem_write8_intercept=write)
+    cpu = _pydrofoil.RISCV64(callbacks=callbacks)
+    ram_base = 0x80000000
+    cpu.write_memory(ram_base, _pydrofoil.bitvector(64, 0x02028593)) # addi a1, t0, 0x20
+    cpu.write_register("pc", ram_base)
+    cpu.step()
+    assert cpu.read_register("pc") == _pydrofoil.bitvector(64, ram_base + 4)
+    assert cpu.read_register("x11") == _pydrofoil.bitvector(64, 0x20)
+    assert len(mem) == 1
+
+
 def test_step_monitor_mem_with_callbacks():
     mem = {}
     def read(addr):

--- a/riscv/pypymodule/test/apptest_plugin.py
+++ b/riscv/pypymodule/test/apptest_plugin.py
@@ -525,6 +525,7 @@ def test_dont_do_reset_vector_without_elf():
     assert cpu.read_register("pc") == _pydrofoil.bitvector(64, ram_base + 4)
     assert cpu.read_register("x11") == _pydrofoil.bitvector(64, 0x20)
     assert len(mem) == 1
+    assert cpu.memory_info() == [(ram_base, ram_base + 7)]
 
 
 def test_step_monitor_mem_with_callbacks():

--- a/riscv/supportcoderiscv.py
+++ b/riscv/supportcoderiscv.py
@@ -390,9 +390,12 @@ def instr_announce(machine, _):
 # sim stuff
 
 @specialize.argtype(0)
-def init_sail(machine, elf_entry):
+def init_sail(machine, elf_entry, write_reset_vector=True):
     machine.init_model()
-    return init_sail_reset_vector(machine, elf_entry)
+    if write_reset_vector:
+        return init_sail_reset_vector(machine, elf_entry)
+    else:
+        return elf_entry
 
 @specialize.argtype(0)
 def is_32bit_model(machine):


### PR DESCRIPTION
* don't write the reset vector in the plugin, if no elf entry is given
* make it possible to specify the sail ram bounds, to make sail bounds checking work