### PR TITLE
Enable Nix build support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+# ^ make editor happy
+
+#
+# Use https://direnv.net/ to automatically load the dev shell.
+#
+
+# if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then
+# source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc="
+# fi
+
+watch_file nix/** flake.nix flake.lock
+use flake . --show-trace

--- a/docs/building_pydrofoil.md
+++ b/docs/building_pydrofoil.md
@@ -81,9 +81,34 @@ Total time (s): 0.000361
 Perf: 844.397835 Kips
 ```
 
-## Build Pydrofoil with Nix
+## Building Pydrofoil with Nix
 
-See [rpypkgs](https://github.com/rpypkgs/rpypkgs) for details.
+Make sure you have already install [Nix](https://nixos.org/install).
+Nix with experiment features `nix-command flakes` is required.
+
+- In-tree build
+
+NOTE: this method requires Nix with version at least 2.28 (otherwise Nix may fail to initalize Git submodules).
+
+After cloning and entering the repo, run the following command to build pydrofoil-riscv:
+
+```bash
+nix build .#pydrofoil-riscv
+```
+
+Or build pydrofoil plugin (for PyPy3):
+
+```bash
+nix build .#pydrofoil-riscv-plugin
+```
+
+Pass `-Lv` to `nix build` if you would like to see verbose build log.
+
+Pass `--out-link <directory>` to specify the target output directory.
+
+- Out-of-tree build
+
+You may also refer to [rpypkgs](https://github.com/rpypkgs/rpypkgs). Note that till now rpypkgs provide only `pydrofoil-riscv` target.
 
 Example usage:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758810218,
+        "narHash": "sha256-pYBGIAuvslEa93oF93K2vIsm8WzppAEoWluXsQCT7cE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08c2ce1f777d8792ccc56f473869f106694fdb80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Pydrofoil development environment with flake-parts";
+
+  inputs = {
+    self.submodules = true;
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.05";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { config, pkgs, ... }:
+        {
+          devShells.default =
+            let
+              pypy2PackageOverrides = [
+                (self: super: {
+                  # Fix rply
+                  appdirs = super.appdirs.overridePythonAttrs (oldAttrs: {
+                    disabled = false;
+                  });
+
+                  # Fix hypothesis
+                  hypothesis = self.callPackage ./nix/hypothesis.nix { };
+                })
+              ];
+
+              pypy2_ =
+                (pkgs.pypy2.override {
+                  packageOverrides = pkgs.lib.composeManyExtensions pypy2PackageOverrides;
+                }).withPackages
+                  (
+                    ps: with ps; [
+                      rply
+                      hypothesis
+                      junit-xml
+                      coverage
+                      typing
+                    ]
+                  );
+
+              python3_ = pkgs.python3.withPackages (
+                ps: with ps; [
+                  pip
+                  pytest
+                  setuptools
+                ]
+              );
+            in
+            pkgs.mkShell {
+              shellHook = ''
+                echo 1>&2 "Welcome to the development shell!"
+                echo 1>&2 "PyPy location: $(which pypy)"
+              '';
+
+              buildInputs = with pkgs; [
+                zlib
+                gmp
+                libffi
+              ];
+
+              packages = with pkgs; [
+                pypy2_
+                self'.packages.${system}.pydrofoil-riscv-plugin
+              ];
+            };
+
+          packages = rec {
+            pydrofoil-riscv = pkgs.callPackage ./package.nix {
+              hypothesis = pkgs.pypy2Packages.callPackage ./nix/hypothesis.nix { };
+            };
+            pydrofoil-riscv-plugin = pkgs.callPackage ./nix/package-plugin.nix {
+              hypothesis = pkgs.pypy2Packages.callPackage ./nix/hypothesis.nix { };
+            };
+            default = pydrofoil-riscv;
+          };
+        };
+    };
+}

--- a/nix/dont_fetch_vendored_deps.patch
+++ b/nix/dont_fetch_vendored_deps.patch
@@ -1,0 +1,12 @@
+diff -ur a/lib_pypy/pypy_tools/build_cffi_imports.py b/lib_pypy/pypy_tools/build_cffi_imports.py
+--- a/lib_pypy/pypy_tools/build_cffi_imports.py	2021-04-12 01:11:48.000000000 -0400
++++ b/lib_pypy/pypy_tools/build_cffi_imports.py	2021-07-16 06:37:03.000000000 -0400
+@@ -225,6 +225,8 @@
+ 
+         print('*', ' '.join(args), file=sys.stderr)
+         if embed_dependencies and key in cffi_dependencies:
++            print("Nixpkgs: skipping fetching/building dependency", key)
++        elif False:
+             status, stdout, stderr = _build_dependency(key)
+             if status != 0:
+                 failures.append((key, module))

--- a/nix/hypothesis.nix
+++ b/nix/hypothesis.nix
@@ -1,0 +1,89 @@
+# Borrowed from nixpkgs/nixos-22.05, with several fixes
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+  isPy3k,
+  coverage,
+  pexpect,
+  doCheck ? false,
+  pytest,
+  pytest-xdist,
+  flaky,
+  mock,
+  sortedcontainers,
+}:
+
+let
+  attrs = buildPythonPackage rec {
+    pname = "attrs";
+    version = "21.2.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-72qqw8ps2SkEzdDYP2KaFfGAU+yE5kMhBvek0Erk9fs=";
+    };
+
+    doCheck = false;
+  };
+
+  enum34 = buildPythonPackage rec {
+    pname = "enum34";
+    version = "1.1.10";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248";
+    };
+
+    doCheck = false;
+  };
+in
+buildPythonPackage rec {
+  # https://hypothesis.readthedocs.org/en/latest/packaging.html
+
+  # Hypothesis has optional dependencies on the following libraries
+  # pytz fake_factory django numpy pytest
+  # If you need these, you can just add them to your environment.
+
+  version = "4.39.3";
+  pname = "hypothesis";
+
+  # Use github tarballs that includes tests
+  src = fetchFromGitHub {
+    owner = "HypothesisWorks";
+    repo = "hypothesis-python";
+    rev = "hypothesis-python-${version}";
+    sha256 = "1qcpcrk6892hzyjsdr581pw6i4fj9035nv89mcjrcrzcmycdlfds";
+  };
+
+  postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
+
+  propagatedBuildInputs = [
+    attrs
+    coverage
+    sortedcontainers
+  ] ++ lib.optional (!isPy3k) enum34;
+
+  checkInputs = [
+    pytest
+    pytest-xdist
+    flaky
+    mock
+    pexpect
+  ];
+
+  inherit doCheck;
+
+  checkPhase = ''
+    rm tox.ini # This file changes how py.test runs and breaks it
+    py.test tests/cover
+  '';
+
+  meta = with lib; {
+    description = "A Python library for property based testing";
+    homepage = "https://github.com/HypothesisWorks/hypothesis";
+    license = licenses.mpl20;
+  };
+}

--- a/nix/package-plugin.nix
+++ b/nix/package-plugin.nix
@@ -1,0 +1,240 @@
+{
+  lib,
+  stdenv,
+  replaceVars,
+  breakpointHook,
+  hypothesis ? null,
+  pkg-config,
+  python3,
+  pypy2,
+  z3,
+  sail-riscv,
+  zlib,
+  gmp,
+  libffi,
+  ncurses,
+  bzip2,
+  openssl,
+  sqlite,
+  tclPackages,
+  tcl,
+  tk,
+  gdbm,
+  xz,
+  expat,
+  python-setup-hook,
+  makeWrapper,
+  patchelf,
+}:
+let
+  pypy2PackageOverrides = [
+    (self: super: {
+      # Fix rply
+      appdirs = super.appdirs.overridePythonAttrs (oldAttrs: {
+        disabled = false;
+      });
+
+      # Fix hypothesis
+      inherit hypothesis;
+    })
+  ];
+
+  pypy2_ =
+    (pypy2.override {
+      packageOverrides = lib.composeManyExtensions pypy2PackageOverrides;
+    }).withPackages
+      (
+        ps: with ps; [
+          rply
+          hypothesis
+          junit-xml
+          coverage
+          typing
+        ]
+      );
+
+  python3_ = python3.withPackages (
+    ps: with ps; [
+      pip
+      pytest
+      setuptools
+    ]
+  );
+
+  pythonVersion = "3.11";
+  libPrefix = "pypy${pythonVersion}";
+  executable = "pypy${lib.versions.majorMinor pythonVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pydrofoil-riscv";
+  version = "0.0.1-alpha0";
+
+  # NOTE: requires Nix 2.28 or later
+  # otherwise `inputs.self.submodules` will fail in flake.nix
+  # src = ./..;
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ../Makefile
+      ../nix
+      ../pydrofoil
+      ../riscv
+      ../pypy2
+    ];
+  };
+
+  # fix compiler error in curses cffi module, where char* != const char*
+  NIX_CFLAGS_COMPILE =
+    if stdenv.cc.isClang then "-Wno-error=incompatible-function-pointer-types" else null;
+  C_INCLUDE_PATH = lib.makeSearchPathOutput "dev" "include" finalAttrs.buildInputs;
+  LIBRARY_PATH = lib.makeLibraryPath finalAttrs.buildInputs;
+  LD_LIBRARY_PATH = lib.makeLibraryPath (
+    builtins.filter (x: x.outPath != stdenv.cc.libc.outPath or "") finalAttrs.buildInputs
+  );
+
+  patchFlags = [
+    "-p1"
+    "--directory"
+    "pypy2"
+  ];
+  patches = [
+    ./dont_fetch_vendored_deps.patch
+
+    (replaceVars ./tk_tcl_paths.patch {
+      inherit tk tcl;
+      tk_dev = tk.dev;
+      tcl_dev = tcl;
+      tk_libprefix = tk.libPrefix;
+      tcl_libprefix = tcl.libPrefix;
+    })
+
+    # Python ctypes.util uses three different strategies to find a library (on Linux):
+    # 1. /sbin/ldconfig
+    # 2. cc -Wl,-t -l"$libname"; objdump -p
+    # 3. ld -t (where it attaches the values in $LD_LIBRARY_PATH as -L arguments)
+    # The first is disabled in Nix (and wouldn't work in the build sandbox or on NixOS anyway), and
+    # the third was only introduced in Python 3.6 (see bugs.python.org/issue9998), so is not
+    # available when buliding PyPy (which is built using Python/PyPy 2.7).
+    # The second requires SONAME to be set for the dynamic library for the second part not to fail.
+    # As libsqlite3 stopped shipping with SONAME after the switch to autosetup (>= 3.50 in Nixpkgs;
+    # see https://www.sqlite.org/src/forumpost/5a3b44f510df8ded). This makes the Python CFFI module
+    # unable to find the SQLite library.
+    # To circumvent these issues, we hardcode the path during build.
+    # For more information, see https://github.com/NixOS/nixpkgs/issues/419942.
+    (replaceVars ./sqlite_paths.patch {
+      inherit (sqlite) out dev;
+      libsqlite = "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pypy2/lib_pypy/pypy_tools/build_cffi_imports.py \
+      --replace-fail "multiprocessing.cpu_count()" "$NIX_BUILD_CORES"
+
+    substituteInPlace pypy2/lib-python/3/tkinter/tix.py\
+      --replace-fail "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tclPackages.tix}/lib'"
+  '';
+
+  nativeBuildInputs = [
+    breakpointHook
+    pkg-config
+    # python3_
+    z3
+    sail-riscv
+    patchelf
+  ];
+
+  buildInputs = [
+    pypy2_
+    bzip2
+    openssl
+    zlib
+    gmp
+    libffi
+    ncurses
+    sqlite
+    tk
+    tcl
+    gdbm
+    xz
+    expat
+    stdenv.cc.libc
+    # boehmgc
+    makeWrapper
+  ];
+
+  # Remove bootstrap python from closure
+  dontPatchShebangs = true;
+  disallowedReferences = [ pypy2 ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C pydrofoil/softfloat/SoftFloat-3e/build/Linux-RISCV-GCC/ softfloat.o
+    pkg-config libffi
+
+    cd pypy2/pypy/goal
+    PYTHONPATH=../../..:${pypy2_}/lib/pypy2.7/site-packages ${pypy2_}/bin/pypy ../../rpython/bin/rpython \
+      --batch \
+      --make-jobs="$NIX_BUILD_CORES" \
+      -Ojit \
+      targetpypystandalone.py \
+      --ext=riscv.pypymodule
+ 	  mv pypy3.11-c pypy-c-pydrofoil-riscv
+ 	  ./pypy-c-pydrofoil-riscv ../../lib_pypy/pypy_tools/build_cffi_imports.py
+ 	  cd -
+ 	  ln -s pypy2/pypy/goal/pypy-c-pydrofoil-riscv pypy-c-pydrofoil-riscv
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cd pypy2/pypy/goal
+    mkdir $out
+    PYTHONPATH=${pypy2_}/lib/pypy2.7/site-packages ${pypy2_}/bin/pypy \
+      ../tool/release/package.py \
+      --override_pypy_c=pypy-c-pydrofoil-riscv \
+      --make-portable \
+      --archive-name=pypy-pydrofoil-scripting-experimental \
+      --targetdir=$out
+    cd $out
+    tar -xjf pypy-pydrofoil-scripting-experimental.tar.bz2 --strip-components=1
+    rm $out/pypy-pydrofoil-scripting-experimental.tar.bz2
+
+    # FIXME: package.py omits bzip2/zlib RPATHs
+    cp ${bzip2.out}/lib/libbz2.so.1 ${zlib.out}/lib/libz.so.1 $out/lib
+    printf "libbz2.so.1\nlibz.so.1\n" >> $out/lib/PYPY_PORTABLE_DEPS.txt
+    patchelf --set-rpath $out/lib $out/bin/lib${libPrefix}-c.so
+
+    ln -s $out/bin/lib${libPrefix}-c.so $out/bin/libpypy3-c.so
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    pushd /
+    $out/bin/${executable} -c "from test import support"
+    popd
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase =
+    let
+      modules = [
+        "curses"
+        "sqlite3"
+        "tkinter"
+        "lzma"
+        "_pydrofoil"
+      ];
+      imports = lib.concatMapStringsSep "; " (x: "import ${x}") modules;
+    in
+    ''
+      echo "Testing whether we can import modules"
+      $out/bin/${executable} -c '${imports}'
+    '';
+    enableParallelBuilding = true; # almost no parallelization without STM
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  hypothesis ? null,
+  pkg-config,
+  python3,
+  pypy2,
+  z3,
+  sail-riscv,
+  zlib,
+  gmp,
+  libffi,
+}:
+let
+  pypy2PackageOverrides = [
+    (self: super: {
+      # Fix rply
+      appdirs = super.appdirs.overridePythonAttrs (oldAttrs: {
+        disabled = false;
+      });
+
+      # Fix hypothesis
+      inherit hypothesis;
+    })
+  ];
+
+  pypy2_ =
+    (pypy2.override {
+      packageOverrides = lib.composeManyExtensions pypy2PackageOverrides;
+    }).withPackages
+      (
+        ps: with ps; [
+          rply
+          hypothesis
+          junit-xml
+          coverage
+          typing
+        ]
+      );
+
+  python3_ = python3.withPackages (
+    ps: with ps; [
+      pip
+      pytest
+      setuptools
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pydrofoil-riscv";
+  version = "0.0.1-alpha0";
+
+  # NOTE: requires Nix 2.28 or later
+  # otherwise `inputs.self.submodules` will fail in flake.nix
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+    pypy2_
+    python3_
+    z3
+    sail-riscv
+  ];
+
+  buildInputs = [
+    zlib
+    gmp
+    libffi
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C pydrofoil/softfloat/SoftFloat-3e/build/Linux-RISCV-GCC/ softfloat.o
+    pkg-config libffi
+
+    # export PYTHONPATH=$PWD:${pypy2_}/lib/pypy2.7/site-packages # not sure if this is still needed
+    PYTHONPATH=. ${pypy2_}/bin/pypy pypy2/rpython/bin/rpython -Ojit --output=pydrofoil-riscv riscv/targetriscv.py
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    ${pypy2_}/bin/pypy pypy2/pytest.py -v pydrofoil/ riscv/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 pydrofoil-riscv $out/bin
+
+    runHook postInstall
+  '';
+})

--- a/nix/sitecustomize.py
+++ b/nix/sitecustomize.py
@@ -1,0 +1,39 @@
+"""
+This is a Nix-specific module for discovering modules built with Nix.
+
+The module recursively adds paths that are on `NIX_PYTHONPATH` to `sys.path`. In
+order to process possible `.pth` files `site.addsitedir` is used.
+
+The paths listed in `PYTHONPATH` are added to `sys.path` afterwards, but they
+will be added before the entries we add here and thus take precedence.
+
+Note the `NIX_PYTHONPATH` environment variable is unset in order to prevent leakage.
+
+Similarly, this module listens to the environment variable `NIX_PYTHONEXECUTABLE`
+and sets `sys.executable` to its value.
+"""
+import site
+import sys
+import os
+import functools
+
+paths = os.environ.pop('NIX_PYTHONPATH', None)
+if paths:
+    functools.reduce(lambda k, p: site.addsitedir(p, k), paths.split(':'), site._init_pathinfo())
+
+# Check whether we are in a venv or virtualenv.
+# For Python 3 we check whether our `base_prefix` is different from our current `prefix`.
+# For Python 2 we check whether the non-standard `real_prefix` is set.
+# https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv
+in_venv = (sys.version_info.major == 3 and sys.prefix != sys.base_prefix) or (sys.version_info.major == 2 and hasattr(sys, "real_prefix"))
+
+if not in_venv:
+    executable = os.environ.pop('NIX_PYTHONEXECUTABLE', None)
+    prefix = os.environ.pop('NIX_PYTHONPREFIX', None)
+
+    if 'PYTHONEXECUTABLE' not in os.environ and executable is not None:
+        sys.executable = executable
+    if prefix is not None:
+        # Sysconfig does not like it when sys.prefix is set to None
+        sys.prefix = sys.exec_prefix = prefix
+        site.PREFIXES.insert(0, prefix)

--- a/nix/sqlite_paths.patch
+++ b/nix/sqlite_paths.patch
@@ -1,0 +1,40 @@
+diff --git a/lib_pypy/_sqlite3_build.py b/lib_pypy/_sqlite3_build.py
+index 2a4e573..92ab786 100644
+--- a/lib_pypy/_sqlite3_build.py
++++ b/lib_pypy/_sqlite3_build.py
+@@ -352,7 +352,7 @@ def _has_load_extension():
+     typedef ... sqlite3;
+     int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -369,7 +369,7 @@ def _has_backup():
+     typedef ... sqlite3_backup;
+     sqlite3_backup* sqlite3_backup_init(sqlite3 *, const char* , sqlite3 *, const char*);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -383,7 +383,7 @@ def _get_version():
+     unverified_ffi.cdef("""
+     int sqlite3_libversion_number(void);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -554,6 +554,8 @@ if sys.platform.startswith('freebsd'):
+ else:
+     extra_args = dict(
+         libraries=libraries,
++        include_dirs=['@dev@/include'],
++        library_dirs=['@out@/lib']
+     )
+ 
+ SOURCE = """

--- a/nix/tk_tcl_paths.patch
+++ b/nix/tk_tcl_paths.patch
@@ -1,0 +1,29 @@
+--- a/lib_pypy/_tkinter/tklib_build.py
++++ b/lib_pypy/_tkinter/tklib_build.py
+@@ -17,23 +17,14 @@ elif sys.platform == 'win32':
+     incdirs = []
+     linklibs = ['tcl85', 'tk85']
+     libdirs = []
+-elif sys.platform == 'darwin':
+-    # homebrew
+-    homebrew = os.environ.get('HOMEBREW_PREFIX', '')
+-    incdirs = ['/usr/local/opt/tcl-tk/include']
+-    linklibs = ['tcl8.6', 'tk8.6']
+-    libdirs = []
+-    if homebrew:
+-        incdirs.append(homebrew + '/include')
+-        libdirs.append(homebrew + '/opt/tcl-tk/lib')
+ else:
+     # On some Linux distributions, the tcl and tk libraries are
+     # stored in /usr/include, so we must check this case also
+-    libdirs = []
++    libdirs = ["@tcl@/lib", "@tk@/lib"]
+     found = False
+     for _ver in ['', '8.6', '8.5']:
+-        incdirs = ['/usr/include/tcl' + _ver]
+-        linklibs = ['tcl' + _ver, 'tk' + _ver]
++        incdirs = ['@tcl_dev@/include', '@tk_dev@/include']
++        linklibs = ['@tcl_libprefix@', '@tk_libprefix@']
+         if os.path.isdir(incdirs[0]):
+             found = True
+             break


### PR DESCRIPTION
Closes #140

Maintain an in-tree build method so that we can easily track dependency versions (and preserve reproducible build as well).